### PR TITLE
Multiple gost instances changes - gost flag --

### DIFF
--- a/common/util/util.go
+++ b/common/util/util.go
@@ -1,0 +1,11 @@
+package util
+
+import (
+	"bytes"
+	"runtime/debug"
+)
+
+// From https://stackoverflow.com/a/70723335
+func GetGoroutineID() string {
+	return string(bytes.Fields(debug.Stack())[1])
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,5 +1,9 @@
 package logger
 
+import (
+	"github.com/go-gost/core/common/util"
+)
+
 // LogFormat is format type
 type LogFormat string
 
@@ -42,12 +46,19 @@ type Logger interface {
 
 var (
 	defaultLogger Logger
+	defaultLoggers = make(map[string]Logger)
 )
 
 func Default() Logger {
+	logger, exists := defaultLoggers[util.GetGoroutineID()]
+
+	if exists {
+		return logger
+	}
 	return defaultLogger
 }
 
 func SetDefault(logger Logger) {
 	defaultLogger = logger
+	defaultLoggers[util.GetGoroutineID()] = logger
 }


### PR DESCRIPTION
Hi!

This PR makes minimal changes in order to support the multi-instance flag added to go-gost in https://github.com/go-gost/gost/pull/64.

It also adds a util function to retrieve the current goroutine ID, which is used to goroutine-isolate all the global/default package variables via hash maps 🙂 
